### PR TITLE
fix(server): only shutdown gRPC if HTTP server is absent

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,7 +84,7 @@ func (s *Server) Serve() {
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.GrpcServer != nil {
+	if s.GrpcServer != nil && s.HttpServer == nil { // shutdown only gRPC server if no HTTP server
 		s.GrpcServer.GracefulStop()
 	}
 	if s.HttpServer != nil {


### PR DESCRIPTION
This PR modifies our shutdown logic to only call gRPC.GracefulStop() when an HTTP server is not enabled.

Why is this change needed?

When we run our service on Cloud Run, we primarily use the HTTP server to handle incoming requests, and gRPC traffic is served over the same port. In this mixed HTTP/gRPC setup, the HTTP server is responsible for managing the graceful shutdown of the entire application.

Calling gRPC.GracefulStop() in this scenario can interfere with the HTTP server's shutdown process, potentially causing premature connection termination or race conditions. The gRPC server should be treated as a "guest" that is shut down automatically when the main HTTP server stops listening.

This approach is based on the recommended practice for shutting down servers that handle both gRPC and other traffic on the same port. For more technical details, see this explanation: [grpc/grpc-go#1384 (comment)](https://github.com/grpc/grpc-go/issues/1384#issuecomment-317124531).

This change ensures a more stable and predictable graceful shutdown, especially in our Cloud Run environment.