### PR TITLE
feat(realip): add gRPC interceptor for real client IP

### DIFF
--- a/pkg/realip/docs.go
+++ b/pkg/realip/docs.go
@@ -1,0 +1,15 @@
+// Package realip provides utilities for extracting the real client IP address from gRPC requests
+// in Google Cloud Run environments.
+//
+// This package offers a gRPC unary server interceptor that reads the X-Forwarded-For header
+// and injects the real client IP (the first IP in the header) into the request context.
+// Cloud Run guarantees that the first IP in X-Forwarded-For is the actual client IP.
+//
+// Usage:
+//
+//	import "github.com/dentech-floss/server/pkg/realip"
+//
+//	grpc.NewServer(grpc.UnaryInterceptor(realip.UnaryServerInterceptor()))
+//
+// The real client IP can be retrieved in handlers using realip.FromContext(ctx).
+package realip

--- a/pkg/realip/realip.go
+++ b/pkg/realip/realip.go
@@ -1,0 +1,73 @@
+package realip
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+type realipKey struct{}
+
+const (
+	XForwardedFor = "X-Forwarded-For"
+)
+
+var noIP = netip.Addr{}
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that extracts the real client IP address
+// from the X-Forwarded-For header and injects it into the context for downstream handlers.
+// This package is intended for use exclusively in Google Cloud Run environments, where Cloud Run guarantees
+// that the first IP address in the X-Forwarded-For header is the actual client IP.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		clientIP := getClientIP(ctx)
+		ctx = context.WithValue(ctx, realipKey{}, clientIP)
+		return handler(ctx, req)
+	}
+}
+
+func getClientIP(ctx context.Context) netip.Addr {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return getIPFromPeer(ctx)
+	}
+
+	forwardedFor := md.Get(XForwardedFor)
+	if len(forwardedFor) == 0 {
+		return getIPFromPeer(ctx)
+	}
+
+	ips := strings.Split(forwardedFor[0], ",")
+	firstIP := strings.TrimSpace(ips[0])
+
+	if ip, err := netip.ParseAddr(firstIP); err == nil {
+		return ip
+	}
+
+	return getIPFromPeer(ctx)
+}
+
+func getIPFromPeer(ctx context.Context) netip.Addr {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return noIP
+	}
+
+	if addrPort, err := netip.ParseAddrPort(p.Addr.String()); err == nil {
+		return addrPort.Addr()
+	}
+
+	return noIP
+}
+
+// FromContext retrieves the real client IP address from the context, if available.
+// The IP is set by the UnaryServerInterceptor in this package.
+// Returns the IP address and a boolean indicating whether the value was present in the context.
+func FromContext(ctx context.Context) (netip.Addr, bool) {
+	ip, ok := ctx.Value(realipKey{}).(netip.Addr)
+	return ip, ok
+}

--- a/pkg/realip/realip_test.go
+++ b/pkg/realip/realip_test.go
@@ -1,0 +1,60 @@
+package realip
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// mockHandler is a simple gRPC handler for testing.
+func mockHandler(t *testing.T, wantIP netip.Addr) grpc.UnaryHandler {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		ip, ok := FromContext(ctx)
+		if !ok {
+			t.Errorf("expected IP in context, got none")
+		}
+		if ip != wantIP {
+			t.Errorf("expected IP %v, got %v", wantIP, ip)
+		}
+		return "ok", nil
+	}
+}
+
+func TestUnaryServerInterceptor_XForwardedFor(t *testing.T) {
+	wantIP := netip.MustParseAddr("203.0.113.42")
+	md := metadata.New(map[string]string{
+		XForwardedFor: "203.0.113.42, 70.41.3.18, 150.172.238.178",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := UnaryServerInterceptor()
+	handler := mockHandler(t, wantIP)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+}
+
+func TestUnaryServerInterceptor_NoXForwardedFor(t *testing.T) {
+	// No X-Forwarded-For, so expect noIP
+	ctx := context.Background()
+	interceptor := UnaryServerInterceptor()
+	handler := mockHandler(t, noIP)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+}
+
+func TestFromContext_NotSet(t *testing.T) {
+	ctx := context.Background()
+	ip, ok := FromContext(ctx)
+	if ok {
+		t.Errorf("expected no IP in context, got %v", ip)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 
+	"github.com/dentech-floss/server/pkg/realip"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 
@@ -48,6 +49,9 @@ func NewServer(config *ServerConfig) *Server {
 	grpcMux := runtime.NewServeMux() // grpc-gateway
 
 	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			realip.UnaryServerInterceptor(),
+		),
 		grpc.StatsHandler(
 			otelgrpc.NewServerHandler(),
 		),


### PR DESCRIPTION
This pull request introduces a new `realip` package that provides a gRPC interceptor for extracting the real client IP address from requests, specifically designed for Google Cloud Run environments. The package is integrated into the gRPC server setup, and comprehensive tests and documentation are included to ensure reliability and ease of use.

**New real IP extraction utility:**

* Added the `realip` package (`pkg/realip/realip.go`) that provides a gRPC unary server interceptor to extract the real client IP from the `X-Forwarded-For` header and inject it into the request context. Includes a helper function `FromContext` for retrieving the IP in handlers.
* Added detailed package-level documentation for `realip` describing its purpose, usage, and Cloud Run-specific guarantees.
* Implemented unit tests for the `realip` package to verify correct extraction and context propagation of the client IP address.

**Integration with gRPC server:**

* Integrated the `realip.UnaryServerInterceptor` into the gRPC server initialization in `server.go`, ensuring all incoming requests have the real client IP available in their context. [[1]](diffhunk://#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996R13) [[2]](diffhunk://#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996R52-R54)