### PR TITLE
feat(server): add GrpcServerOptions to ServerConfig

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,7 +52,7 @@ func NewServer(config *ServerConfig) *Server {
 
 	var opts []grpc.ServerOption
 	if config.WithRealIP {
-		opts = append(opts, grpc.UnaryInterceptor(
+		opts = append(opts, grpc.ChainUnaryInterceptor(
 			realip.UnaryServerInterceptor(),
 		))
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	HttpAndGrpcHandlerFunc HttpAndGrpcHandlerFunc
 	HandlerOptions         *HttpAndGrpcHandlerOptions
 	WithRealIP             bool
+	GrpcServerOptions      []grpc.ServerOption
 }
 
 func (c *ServerConfig) setDefaults() {
@@ -59,6 +60,8 @@ func NewServer(config *ServerConfig) *Server {
 	opts = append(opts, grpc.StatsHandler(
 		otelgrpc.NewServerHandler(),
 	))
+
+	opts = append(opts, config.GrpcServerOptions...)
 
 	grpcServer := grpc.NewServer(opts...)
 


### PR DESCRIPTION
## Summary

- Adds optional `GrpcServerOptions []grpc.ServerOption` field to `ServerConfig`
- These options are appended to the internal opts slice before `grpc.NewServer()` is called
- Fully backward-compatible — existing callers are unaffected (nil slice is a no-op)

## Motivation

The gRPC default max receive message size is 4MB. Services that accept file attachments (e.g. objection screenshots) need to raise this limit. With this field, callers can pass `grpc.MaxRecvMsgSize(n)` without the server package needing to know about every possible gRPC option.

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing callers compile unchanged (no new required fields)
- [ ] invoice-service updated to pass `grpc.MaxRecvMsgSize(20 * 1024 * 1024)` and objection screenshot uploads succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ServerConfig now accepts custom gRPC server options, providing enhanced flexibility for server configuration. Custom options are applied after default built-in options, ensuring existing behavior remains unchanged while enabling additional configuration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->